### PR TITLE
Ensure that the example queue exists before binding it.

### DIFF
--- a/src/examples.lisp
+++ b/src/examples.lisp
@@ -20,6 +20,7 @@
       (channel-open conn 1)
       (exchange-declare conn 1 "test-ex" "topic")
       (let ((queue-name "foo"))
+        (queue-declare conn 1 :queue queue-name)
         (queue-bind conn 1 :queue queue-name :exchange "test-ex" :routing-key "xx")
         (basic-consume conn 1 queue-name)
         (let* ((result (consume-message conn))


### PR DESCRIPTION
Slight tweek to the example so test-recv can run even if the user hasn't previously created a queue foo. It might be appropriate to make the queue :auto-delete t, except (a) then it will break if the user does already have a queue foo, and (b) not making it auto-delete aligns with what is in the first RabbitMQ tutorial.